### PR TITLE
Replace CDTs with Conda packages & cleanup `yum_requirements.txt`

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -54,7 +54,7 @@ ulimit -n 1024
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libglvnd libglvnd-opengl mesa-libGL mesa-libEGL-devel xorg-x11-server-Xvfb
+/usr/bin/sudo -n yum install -y xorg-x11-server-Xvfb
 )
 
 # make the build number clobber

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,6 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - {{ cdt('libglvnd') }}  # [linux]
-    - {{ cdt('libglvnd-opengl') }}  # [linux]
     - {{ stdlib("c") }}
     - arm-variant * {{ arm_variant_type }}  # [aarch64]
   host:
@@ -41,6 +39,8 @@ requirements:
     - expat
     - fontconfig
     - freetype
+    - libglvnd-devel       # [linux]
+    - libopengl-devel      # [linux]
     - krb5
     - libglib
     - libxcb

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,5 +1,1 @@
-libglvnd
-libglvnd-opengl
-mesa-libGL
-mesa-libEGL-devel
 xorg-x11-server-Xvfb


### PR DESCRIPTION
Part of issue: https://github.com/conda-forge/cuda-feedstock/issues/28

Previously we used CDTs for `libglvnd*`. However this was since packaged in conda-forge and it would be better to depend on that package so users pull it in when installing. Especially so as this CDT is not provided on AlmaLinux 8. This makes that change. Also this change is being rolled out in conda-forge.

Cleans up `yum_requirements.txt` as well.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
